### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -43,6 +43,9 @@ jobs:
     name: 'Unit tests'
     runs-on: 'ubuntu-latest'
 
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
Potential fix for [https://github.com/Jujulego/palantir/security/code-scanning/15](https://github.com/Jujulego/palantir/security/code-scanning/15)

To fix the issue, we will add a `permissions` block to the `unit-tests` job. Since the job primarily involves running tests and uploading results, it does not require write access to the repository. The minimal permissions required are `contents: read`. This ensures the job can read the repository contents without granting unnecessary write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
